### PR TITLE
Bumping command line tools

### DIFF
--- a/Formula/commandline-tools.rb
+++ b/Formula/commandline-tools.rb
@@ -1,9 +1,9 @@
 class CommandlineTools < Formula
   desc "Command line tools used by Notre Dame Libraries"
   homepage "https://github.com/ndlib/commandline-tools"
-  url "https://github.com/ndlib/commandline-tools/archive/v2017.7.tar.gz"
-  version "v2017.7"
-  sha256 "a9090fe1d008517eb1e65ed521f5b3a65d397c6835189cf7aba6f7bfa625ff3f"
+  url "https://github.com/ndlib/commandline-tools/archive/v2017.9.tar.gz"
+  version "v2017.9"
+  sha256 "a9b3a9c2304f1e0cf44838c96b57b5c1ff0b7e8935de1c89c7643e75b8df59d1"
   depends_on "git" => :run
   depends_on "screen" => :run
 


### PR DESCRIPTION
* Resolves issue where `-h` option for `bin/build-pull-request-message`
  fails