### PR TITLE
Fix homebrew formulae

### DIFF
--- a/Formula/commandline-tools.rb
+++ b/Formula/commandline-tools.rb
@@ -2,11 +2,9 @@ class CommandlineTools < Formula
   desc "Command line tools used by Notre Dame Libraries"
   homepage "https://github.com/ndlib/commandline-tools"
   url "https://github.com/ndlib/commandline-tools/archive/v2017.10.tar.gz"
-  version "v2017.9"
   sha256 "4e208c3852d606f2e0cdc8eb6fca651120d069d6a7f4faef8ed3d835fe275e1d"
-  depends_on "git" => :run
-  depends_on "screen" => :run
-  depends_on "ag" => :run
+  depends_on "screen"
+  depends_on "the_silver_searcher"
 
   def install
     bin.install "bin/build-pull-request-message"

--- a/Formula/go-jira.rb
+++ b/Formula/go-jira.rb
@@ -2,7 +2,6 @@ class GoJira < Formula
   desc "Command line client for JIRA."
   homepage "https://github.com/Netflix-Skunkworks/go-jira"
   url "https://github.com/Netflix-Skunkworks/go-jira/archive/v0.1.14.tar.gz"
-  version "0.1.14"
   sha256 "561f388a0dcb6da531469fa913f9e5377f30f406b2afab78f6a0dd66b5352384"
   # send the password prompt to stderr. do this until upstream either sends the
   # prompt to stderr or until it supports putting the password in a file. this


### PR DESCRIPTION
No version updates. Remove deprecated "depends_on ... => :run" syntax.
Remove redundant "git" dependency. Remove version field since homebrew
can extract the version from the source URL.